### PR TITLE
Fix a path issue in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ any other accessible Maven repository. A Maven plug-in is provided which must be
 in your local Maven repository for any of the builds to be successful.
 
 1. Install Java (at least Java 7) and Maven
-2. Clone this repository and go into the repository root folder.
-3. `mvn -f ebr/releng/ebr-maven-plugin/pom.xml install`
+2. Clone this repository and go into the repository root folder
+3. `mvn -f releng/ebr-maven-plugin/pom.xml install`
 
 
 


### PR DESCRIPTION
The instructions say 'go into the repository root folder' (which is ebr/), 
but then ebr/ is used in the path on the mvn build line.
